### PR TITLE
Update margin

### DIFF
--- a/src/Components/BeforeRank/style.ts
+++ b/src/Components/BeforeRank/style.ts
@@ -4,7 +4,7 @@ import device from "Shared/Config";
 export const BeforeRankPage = styled.div`
   display: flex;
   justify-content: space-between;
-  margin: 115px 5vw 0 5vw;
+  margin: 180px 5vw 0 5vw;
   width: 90vw;
 
   @media ${device.laptop} {
@@ -21,7 +21,7 @@ export const BeforeRankPage = styled.div`
 
 export const RightBox = styled.div`
   width: 990px;
-  margin-top: 90px;
+  margin-top: 32px;
   @media ${device.mobile} {
     margin-top: 30px;
     width: 100%;


### PR DESCRIPTION
## 개요

> 디자인과 다른 지난 top3 보기 페이지의 margin을 수정하였다

## 작업사항

> BeforeRankPage - ```margin: 115px 5vw 0 5vw; -> margin: 180px 5vw 0 5vw;```
> RightBox - ```margin-top: 90px; -> margin-top: 32px;```

<img width="2048" alt="스크린샷 2021-12-24 오전 11 13 39" src="https://user-images.githubusercontent.com/80103328/147307929-90a2a8b3-aa05-4d4a-832c-315eea7c05bc.png">

